### PR TITLE
explicitly issued environment variable as per - https://github.com/dockerfile/m...

### DIFF
--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -14,4 +14,7 @@ RUN cp -Rip /var/lib/mysql /var/lib/orig-mysql
 VOLUME /var/lib/mysql
 EXPOSE 3306
 
+#As per: https://github.com/dockerfile/mariadb/issues/3
+ENV TERM dumb
+
 CMD [ "/usr/sbin/prep_and_mysqld_safe", "--skip-syslog" ]


### PR DESCRIPTION
...ariadb/issues/3

This may be a result of the `docker exec` command (Docker.v.1.3 +)  so is only recently apparent, but when you `docker exec bash` into the running mariadb container and subsequently attempt to access the database with the `mysql` command it throws an error `TERM environment variable not set.` 

A fix is to run `export TERM=dumb` and then run `mysql` again.

Similarly, by explicitly setting environment variable in the dockerfile, the error message never appears, i.e. adding `ENV TERM dumb`

Note: I have only used the first method successfully but have added the solution to this Dockerfile based on the documentation of this issue here: https://github.com/dockerfile/mariadb/issues/3 